### PR TITLE
Add Swagger security requirement annotations and configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.6.0</version>
-
 		</dependency>
 
 		<dependency>

--- a/src/main/java/us/cloud/teachme/studentservice/web/controller/HealthCheckController.java
+++ b/src/main/java/us/cloud/teachme/studentservice/web/controller/HealthCheckController.java
@@ -1,5 +1,6 @@
 package us.cloud.teachme.studentservice.web.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
+@SecurityRequirement(name = "Authorization")
 public class HealthCheckController {
 
     @GetMapping("/health")

--- a/src/main/java/us/cloud/teachme/studentservice/web/controller/StudentController.java
+++ b/src/main/java/us/cloud/teachme/studentservice/web/controller/StudentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/students")
 @AllArgsConstructor
+@SecurityRequirement(name = "Authorization")
 @Tag(name = "Student Management", description = "APIs for managing students of the teachme platform")
 public class StudentController {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,7 @@ resilience4j.circuitbreaker.instances.student-service.minimumNumberOfCalls=15
 resilience4j.circuitbreaker.instances.student-service.waitDurationInOpenState=30s
 resilience4j.circuitbreaker.instances.student-service.failureRateThreshold=40
 resilience4j.circuitbreaker.instances.student-service.eventConsumerBufferSize=20
+
+# Swagger
+springdoc.swagger-ui.path=/swagger/student-service/index.html
+springdoc.api-docs.path=/swagger/student-service/api-docs


### PR DESCRIPTION
Integrate `@SecurityRequirement` annotations into controllers to enforce security requirements for API endpoints. Update `application.properties` with Swagger UI and API docs paths for better documentation accessibility. Clean up unused dependency spacing in `pom.xml`.